### PR TITLE
Revise package synopsis and description.

### DIFF
--- a/monoidmap-aeson.cabal
+++ b/monoidmap-aeson.cabal
@@ -8,8 +8,8 @@ author:         Jonathan Knowles
 maintainer:     mail@jonathanknowles.net
 copyright:      2022–2025 Jonathan Knowles
 category:       Data Structures
-synopsis:       JSON support for monoidmap, compatible with aeson.
-description:    JSON support for monoidmap, compatible with aeson.
+synopsis:       JSON support for monoidmap.
+description:    JSON support for the monoidmap package, compatible with aeson.
 
 extra-doc-files:
     CHANGELOG.md


### PR DESCRIPTION
This is to satisfy `cabal check`, which reports the following error if the synopsis and description fields are the same length:

```
$ cabal check
Warning: [short-description] The 'description' field should be longer than the
'synopsis' field. It's useful to provide an informative 'description' to allow
Haskell programmers who have never heard about your package to understand the
purpose of your package.
```